### PR TITLE
Implement live Open-Meteo integrations and modernize dashboard UI

### DIFF
--- a/config/container_bindings.php
+++ b/config/container_bindings.php
@@ -3,7 +3,9 @@
 declare(strict_types = 1);
 
 use App\Config;
+use App\Controller\ApiController;
 use App\Controller\ErrorController;
+use App\Service\WeatherService;
 use Slim\Views\Twig;
 use Twig\Extra\Intl\IntlExtension;
 
@@ -21,4 +23,6 @@ return [
         return $twig;
     },
     ErrorController::class => create(ErrorController::class),
+    WeatherService::class => create(WeatherService::class),
+    ApiController::class => create(ApiController::class),
 ];

--- a/config/routes.php
+++ b/config/routes.php
@@ -3,6 +3,7 @@
 declare(strict_types = 1);
 
 use App\Config;
+use App\Controller\ApiController;
 use App\Controller\AuthController;
 use App\Controller\DashboardController;
 use App\Controller\LoginController;
@@ -41,39 +42,9 @@ return function (App $app) {
     $app->get('/', [DashboardController::class, 'index'])->add(new AuthMiddleware($secret));
 
     $app->group('/api', function (RouteCollectorProxy $group)  {
-        $group->get('/page1', function (Request $request, Response $response) { 
-            $result = file_get_contents('https://dummyjson.com/posts?limit=50&sortBy=id&order=asc');
-            
-            if ($result === false) {
-                $response->getBody()->write(json_encode(['error' => 'API call failed']));
-                return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
-            }
-
-            $response->getBody()->write($result); 
-            return $response->withHeader('Content-Type', 'application/json'); 
-        });
-        $group->get('/page2', function (Request $request, Response $response) { 
-            $result = file_get_contents('https://dummyjson.com/posts?limit=50&sortBy=views&order=desc');
-            
-            if ($result === false) {
-                $response->getBody()->write(json_encode(['error' => 'API call failed']));
-                return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
-            }
-
-            $response->getBody()->write($result); 
-            return $response->withHeader('Content-Type', 'application/json'); 
-        });
-        $group->get('/page3', function (Request $request, Response $response) { 
-            $result = file_get_contents('https://dummyjson.com/posts?limit=50&sortBy=title&order=desc');
-            
-            if ($result === false) {
-                $response->getBody()->write(json_encode(['error' => 'API call failed']));
-                return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
-            }
-
-            $response->getBody()->write($result); 
-            return $response->withHeader('Content-Type', 'application/json'); 
-        });
+        $group->get('/weather/overview', [ApiController::class, 'overview']);
+        $group->get('/weather/air-quality', [ApiController::class, 'airQuality']);
+        $group->get('/weather/solar', [ApiController::class, 'solar']);
     })->add(new AuthMiddleware($secret));
 
     // Catch-all Route nach der Fehler-Middleware

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,31 +1,143 @@
 body {
-    background-color: #f4f5f7;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: linear-gradient(180deg, #f7f9fc 0%, #eef2f6 100%);
+    color: #111827;
 }
 
-.card {
-    border-radius: 12px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+.gradient-bg {
+    background: linear-gradient(135deg, #0d6efd 0%, #60a5fa 45%, #34d399 100%);
+    position: relative;
+    overflow: hidden;
 }
-.btn-modern {
-    border-radius: 20px;
-    padding: 0.5rem 1.5rem;
-}
-.pagination .page-item.active .page-link {
-    background-color: #0d6efd;
-    border-color: #0d6efd;
-    color: white;
-}
-.pagination .page-link {
+
+.gradient-bg::after {
+    content: '';
+    position: absolute;
+    top: -40%;
+    right: -10%;
+    width: 320px;
+    height: 320px;
+    background: rgba(255, 255, 255, 0.12);
+    filter: blur(20px);
     border-radius: 50%;
-    width: 40px;
-    height: 40px;
+}
+
+.gradient-bg::before {
+    content: '';
+    position: absolute;
+    bottom: -30%;
+    left: -5%;
+    width: 240px;
+    height: 240px;
+    background: rgba(255, 255, 255, 0.1);
+    filter: blur(30px);
+    border-radius: 50%;
+}
+
+.gradient-bg > * {
+    position: relative;
+    z-index: 2;
+}
+
+.glass-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-radius: 20px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+    backdrop-filter: blur(10px);
+    padding: 1.75rem;
+}
+
+.metric-pill {
+    border-radius: 14px;
+    background: rgba(13, 110, 253, 0.08);
+    padding: 0.75rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.metric-pill .label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #6b7280;
+}
+
+.metric-pill .value {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.hero-icon {
+    font-size: 1.5rem;
+}
+
+.dataset-switch {
+    border-radius: 999px !important;
+    padding: 0.65rem 1.5rem;
+    font-weight: 600;
+    transition: all 0.3s ease;
+}
+
+.dataset-switch.active,
+.dataset-switch:hover,
+.dataset-switch:focus {
+    color: #fff !important;
+    background: linear-gradient(135deg, #0d6efd 0%, #2563eb 100%);
+    box-shadow: 0 12px 30px rgba(37, 99, 235, 0.3);
+}
+
+.pagination-rounded .page-link {
+    border-radius: 999px;
+    width: 42px;
+    height: 42px;
     display: flex;
     justify-content: center;
     align-items: center;
+    border: none;
+    color: #0f172a;
+    font-weight: 600;
+    transition: transform 0.2s ease;
 }
-.chart-controls {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-    margin-bottom: 10px;
+
+.pagination-rounded .page-link:hover {
+    transform: translateY(-2px);
+    background: rgba(13, 110, 253, 0.1);
+}
+
+.pagination-rounded .page-item.active .page-link {
+    background: linear-gradient(135deg, #0d6efd 0%, #2563eb 100%);
+    color: #fff;
+}
+
+table thead {
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+}
+
+table tbody tr {
+    transition: background 0.2s ease;
+}
+
+table tbody tr:hover {
+    background: rgba(15, 23, 42, 0.04);
+}
+
+#chartCanvas {
+    background: radial-gradient(circle at top, rgba(13, 110, 253, 0.08), transparent 55%);
+    border-radius: 20px;
+    padding: 0.5rem;
+}
+
+@media (max-width: 768px) {
+    .glass-card {
+        padding: 1.25rem;
+    }
+
+    .dataset-switch {
+        padding: 0.5rem 1.25rem;
+    }
 }

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1,142 +1,526 @@
-let currentDataSet = [];
-let currentPage = 1;
-let entriesPerPage = 10;
-let chartType = 'bar';
+const state = {
+    currentDataset: 'weather',
+    currentPage: 1,
+    entriesPerPage: 6,
+    chartType: 'line',
+    data: {},
+};
 
-const tableBody = document.querySelector('#dataTableBody');
+const selectors = {
+    tableBody: document.getElementById('dataTableBody'),
+    tableHead: document.getElementById('tableHeadRow'),
+    tableMeta: document.getElementById('tableMeta'),
+    currentPage: document.getElementById('currentPage'),
+    tableTitle: document.getElementById('tableTitle'),
+    tableSubtitle: document.getElementById('tableSubtitle'),
+    chartNote: document.getElementById('chartNote'),
+    dataSource: document.getElementById('dataSource'),
+    heroTemperature: document.getElementById('heroTemperature'),
+    heroCondition: document.getElementById('heroCondition'),
+    locationLabel: document.getElementById('locationLabel'),
+    currentTemperature: document.getElementById('currentTemperature'),
+    currentFeelsLike: document.getElementById('currentFeelsLike'),
+    currentUpdatedAt: document.getElementById('currentUpdatedAt'),
+    currentHumidity: document.getElementById('currentHumidity'),
+    currentWind: document.getElementById('currentWind'),
+    currentRainChance: document.getElementById('currentRainChance'),
+    metricPrimary: document.querySelector('[data-metric="primary"] .label'),
+    metricSecondary: document.querySelector('[data-metric="secondary"] .label'),
+    metricTertiary: document.querySelector('[data-metric="tertiary"] .label'),
+    highlightPrimary: document.querySelector('[data-highlight="primary"] .badge'),
+    highlightSecondary: document.querySelector('[data-highlight="secondary"] .badge'),
+    highlightTertiary: document.querySelector('[data-highlight="tertiary"] .badge'),
+    highlightPrimaryTitle: document.getElementById('highlightPrimaryTitle'),
+    highlightPrimaryText: document.getElementById('highlightPrimaryText'),
+    highlightSecondaryTitle: document.getElementById('highlightSecondaryTitle'),
+    highlightSecondaryText: document.getElementById('highlightSecondaryText'),
+    highlightTertiaryTitle: document.getElementById('highlightTertiaryTitle'),
+    highlightTertiaryText: document.getElementById('highlightTertiaryText'),
+};
 
-const showLoader = () => {
-    tableBody.innerHTML = `
-        <tr>
-            <td colspan="5" class="text-center">
-                <div class="spinner-border text-primary" role="status">
-                    <span class="visually-hidden">Loading...</span>
-                </div>
-            </td>
-        </tr>`;
+const datasetConfig = {
+    weather: {
+        endpoint: '/api/weather/overview',
+        table: {
+            columns: [
+                { key: 'time', label: 'Zeit', formatter: (value) => formatHour(value) },
+                { key: 'temperature', label: 'Temperatur (°C)', formatter: (value) => formatNumber(value, '°C') },
+                { key: 'apparentTemperature', label: 'Gefühlt (°C)', formatter: (value) => formatNumber(value, '°C') },
+                { key: 'humidity', label: 'Luftfeuchte (%)', formatter: (value) => formatNumber(value, '%') },
+                { key: 'windSpeed', label: 'Wind (km/h)', formatter: (value) => formatNumber(value, ' km/h') },
+                { key: 'precipitationProbability', label: 'Regenchance (%)', formatter: (value) => formatNumber(value, '%') },
+            ],
+        },
+        chart: {
+            note: 'Temperatur, gefühlte Temperatur und Wind im Vergleich (stündlich).',
+            datasets: [
+                {
+                    key: 'temperature',
+                    label: 'Temperatur (°C)',
+                    backgroundColor: 'rgba(13, 110, 253, 0.35)',
+                    borderColor: '#0d6efd',
+                },
+                {
+                    key: 'apparentTemperature',
+                    label: 'Gefühlt (°C)',
+                    backgroundColor: 'rgba(96, 165, 250, 0.35)',
+                    borderColor: '#60a5fa',
+                },
+                {
+                    key: 'windSpeed',
+                    label: 'Wind (km/h)',
+                    backgroundColor: 'rgba(52, 211, 153, 0.35)',
+                    borderColor: '#34d399',
+                },
+            ],
+        },
+        apply: (payload) => {
+            selectors.locationLabel.textContent = payload.meta?.location ?? '—';
+            selectors.heroTemperature.textContent = formatNumber(payload.current?.temperature, '°C');
+            selectors.heroCondition.textContent = payload.current?.description ?? 'Aktualisiert';
+            selectors.currentTemperature.textContent = formatNumber(payload.current?.temperature, '°C');
+            selectors.currentFeelsLike.textContent = formatNumber(payload.current?.apparentTemperature, '°C');
+            selectors.currentUpdatedAt.textContent = formatDateTime(payload.current?.time);
+
+            selectors.metricPrimary.textContent = 'Luftfeuchtigkeit';
+            selectors.metricSecondary.textContent = 'Wind';
+            selectors.metricTertiary.textContent = 'Regenrisiko';
+
+            selectors.currentHumidity.textContent = formatNumber(payload.current?.humidity, '%');
+            selectors.currentWind.textContent = formatNumber(payload.current?.windSpeed, ' km/h');
+            selectors.currentRainChance.textContent = formatNumber(payload.highlights?.rainChance, '%');
+
+            selectors.highlightPrimary.textContent = 'Temperatur';
+            selectors.highlightSecondary.textContent = 'Wind';
+            selectors.highlightTertiary.textContent = 'Sonne';
+            selectors.highlightPrimary.className = 'badge rounded-pill bg-primary-subtle text-primary mb-2';
+            selectors.highlightSecondary.className = 'badge rounded-pill bg-success-subtle text-success mb-2';
+            selectors.highlightTertiary.className = 'badge rounded-pill bg-warning-subtle text-warning mb-2';
+
+            selectors.highlightPrimaryTitle.textContent = 'Tagesverlauf';
+            selectors.highlightPrimaryText.textContent = `Max ${formatNumber(payload.highlights?.maxTemperature, '°C')} · Min ${formatNumber(payload.highlights?.minTemperature, '°C')}`;
+            selectors.highlightSecondaryTitle.textContent = 'Durchschnittliche Geschwindigkeit';
+            selectors.highlightSecondaryText.textContent = formatNumber(payload.highlights?.averageWindSpeed, ' km/h');
+            selectors.highlightTertiaryTitle.textContent = 'Tageslicht';
+            selectors.highlightTertiaryText.textContent = `Aufgang ${formatHour(payload.highlights?.sunrise)} · Untergang ${formatHour(payload.highlights?.sunset)}`;
+
+            selectors.tableTitle.textContent = 'Stündliche Wetterdaten';
+            selectors.tableSubtitle.textContent = 'Vergleich von Temperatur, gefühlter Temperatur, Luftfeuchte und Windstärke.';
+            selectors.chartNote.textContent = datasetConfig.weather.chart.note;
+            selectors.dataSource.textContent = `Quelle: ${payload.meta?.source ?? 'Open‑Meteo'}`;
+        },
+    },
+    'air-quality': {
+        endpoint: '/api/weather/air-quality',
+        table: {
+            columns: [
+                { key: 'time', label: 'Zeit', formatter: (value) => formatHour(value) },
+                { key: 'pm25', label: 'PM2.5 (µg/m³)', formatter: (value) => formatNumber(value, ' µg/m³') },
+                { key: 'pm10', label: 'PM10 (µg/m³)', formatter: (value) => formatNumber(value, ' µg/m³') },
+                { key: 'ozone', label: 'Ozon (µg/m³)', formatter: (value) => formatNumber(value, ' µg/m³') },
+                { key: 'carbonMonoxide', label: 'CO (µg/m³)', formatter: (value) => formatNumber(value, ' µg/m³') },
+            ],
+        },
+        chart: {
+            note: 'Feinstaub (PM2.5/PM10) und Ozonbelastung pro Stunde.',
+            datasets: [
+                {
+                    key: 'pm25',
+                    label: 'PM2.5',
+                    backgroundColor: 'rgba(220, 38, 38, 0.35)',
+                    borderColor: '#dc2626',
+                },
+                {
+                    key: 'pm10',
+                    label: 'PM10',
+                    backgroundColor: 'rgba(249, 115, 22, 0.35)',
+                    borderColor: '#f97316',
+                },
+                {
+                    key: 'ozone',
+                    label: 'Ozon',
+                    backgroundColor: 'rgba(245, 158, 11, 0.35)',
+                    borderColor: '#f59e0b',
+                },
+            ],
+        },
+        apply: (payload) => {
+            selectors.locationLabel.textContent = payload.meta?.location ?? '—';
+            selectors.heroTemperature.textContent = `${formatNumber(payload.airQualityIndex?.score, '')} AQI`;
+            selectors.heroCondition.textContent = payload.airQualityIndex?.category ?? '—';
+            selectors.currentTemperature.textContent = `${formatNumber(payload.airQualityIndex?.score, '')} AQI`;
+            selectors.currentFeelsLike.textContent = payload.airQualityIndex?.category ?? '—';
+            selectors.currentUpdatedAt.textContent = formatDateTime(payload.meta?.updatedAt);
+
+            selectors.metricPrimary.textContent = 'Ø PM2.5';
+            selectors.metricSecondary.textContent = 'PM10 Peak';
+            selectors.metricTertiary.textContent = 'Ozon Peak';
+
+            selectors.currentHumidity.textContent = formatNumber(payload.highlights?.averagePm25, ' µg/m³');
+            selectors.currentWind.textContent = formatNumber(payload.highlights?.maxPm10, ' µg/m³');
+            selectors.currentRainChance.textContent = formatNumber(payload.highlights?.maxOzone, ' µg/m³');
+
+            selectors.highlightPrimary.textContent = 'Luftqualität';
+            selectors.highlightSecondary.textContent = 'Empfehlung';
+            selectors.highlightTertiary.textContent = 'Belastung';
+            selectors.highlightPrimary.className = `badge rounded-pill bg-${payload.airQualityIndex?.color ?? 'primary'}-subtle text-${payload.airQualityIndex?.color ?? 'primary'} mb-2`;
+            selectors.highlightSecondary.className = 'badge rounded-pill bg-info-subtle text-info mb-2';
+            selectors.highlightTertiary.className = 'badge rounded-pill bg-warning-subtle text-warning mb-2';
+
+            selectors.highlightPrimaryTitle.textContent = 'Air Quality Index';
+            selectors.highlightPrimaryText.textContent = `Durchschnittlicher AQI ${formatNumber(payload.airQualityIndex?.score, '')}`;
+            selectors.highlightSecondaryTitle.textContent = 'Gesundheitstipp';
+            selectors.highlightSecondaryText.textContent = payload.airQualityIndex?.message ?? 'Aktualisierung steht aus.';
+            selectors.highlightTertiaryTitle.textContent = 'Stärkster Wert';
+            selectors.highlightTertiaryText.textContent = `PM10 Spitze ${formatNumber(payload.highlights?.maxPm10, ' µg/m³')}`;
+
+            selectors.tableTitle.textContent = 'Luftqualitäts-Monitoring';
+            selectors.tableSubtitle.textContent = 'Partikel- und Gasbelastungen je Stunde im Überblick.';
+            selectors.chartNote.textContent = datasetConfig['air-quality'].chart.note;
+            selectors.dataSource.textContent = `Quelle: ${payload.meta?.source ?? 'Open‑Meteo'}`;
+        },
+    },
+    solar: {
+        endpoint: '/api/weather/solar',
+        table: {
+            columns: [
+                { key: 'time', label: 'Zeit', formatter: (value) => formatHour(value) },
+                { key: 'shortwaveRadiation', label: 'Global (W/m²)', formatter: (value) => formatNumber(value, ' W/m²') },
+                { key: 'directRadiation', label: 'Direkt (W/m²)', formatter: (value) => formatNumber(value, ' W/m²') },
+                { key: 'diffuseRadiation', label: 'Diffus (W/m²)', formatter: (value) => formatNumber(value, ' W/m²') },
+                { key: 'directNormalIrradiance', label: 'DNI (W/m²)', formatter: (value) => formatNumber(value, ' W/m²') },
+            ],
+        },
+        chart: {
+            note: 'Solarstrahlung zur Abschätzung des Energiepotenzials.',
+            datasets: [
+                {
+                    key: 'shortwaveRadiation',
+                    label: 'Globalstrahlung',
+                    backgroundColor: 'rgba(250, 204, 21, 0.35)',
+                    borderColor: '#facc15',
+                },
+                {
+                    key: 'directRadiation',
+                    label: 'Direktstrahlung',
+                    backgroundColor: 'rgba(253, 186, 116, 0.35)',
+                    borderColor: '#f97316',
+                },
+                {
+                    key: 'diffuseRadiation',
+                    label: 'Diffusstrahlung',
+                    backgroundColor: 'rgba(251, 191, 36, 0.35)',
+                    borderColor: '#fbbf24',
+                },
+            ],
+        },
+        apply: (payload) => {
+            selectors.locationLabel.textContent = payload.meta?.location ?? '—';
+            selectors.heroTemperature.textContent = formatNumber(payload.highlights?.peakRadiation, ' W/m²');
+            selectors.heroCondition.textContent = 'Maximale Solarleistung';
+            selectors.currentTemperature.textContent = formatNumber(payload.highlights?.peakRadiation, ' W/m²');
+            selectors.currentFeelsLike.textContent = 'Solarspitze';
+            selectors.currentUpdatedAt.textContent = formatDateTime(payload.meta?.updatedAt);
+
+            selectors.metricPrimary.textContent = 'Global Ø';
+            selectors.metricSecondary.textContent = 'Direkt Ø';
+            selectors.metricTertiary.textContent = 'Tageslicht';
+
+            const hourly = payload.hourly ?? [];
+            selectors.currentHumidity.textContent = formatNumber(averageFromSeries(hourly, 'shortwaveRadiation'), ' W/m²');
+            selectors.currentWind.textContent = formatNumber(averageFromSeries(hourly, 'directRadiation'), ' W/m²');
+            selectors.currentRainChance.textContent = `Tageslicht ${formatNumber(payload.highlights?.daylightHours, ' h')}`;
+
+            selectors.highlightPrimary.textContent = 'Solarenergie';
+            selectors.highlightSecondary.textContent = 'Tagesverlauf';
+            selectors.highlightTertiary.textContent = 'Sonnenfenster';
+            selectors.highlightPrimary.className = 'badge rounded-pill bg-warning-subtle text-warning mb-2';
+            selectors.highlightSecondary.className = 'badge rounded-pill bg-info-subtle text-info mb-2';
+            selectors.highlightTertiary.className = 'badge rounded-pill bg-success-subtle text-success mb-2';
+
+            selectors.highlightPrimaryTitle.textContent = 'Peak-Leistung';
+            selectors.highlightPrimaryText.textContent = `Maximal ${formatNumber(payload.highlights?.peakRadiation, ' W/m²')}`;
+            selectors.highlightSecondaryTitle.textContent = 'Durchschnittswerte';
+            selectors.highlightSecondaryText.textContent = `${formatNumber(averageFromSeries(hourly, 'shortwaveRadiation'), ' W/m²')} im Mittel`;
+            selectors.highlightTertiaryTitle.textContent = 'Sonnenfenster';
+            selectors.highlightTertiaryText.textContent = `Aufgang ${formatHour(payload.highlights?.sunrise)} · Untergang ${formatHour(payload.highlights?.sunset)}`;
+
+            selectors.tableTitle.textContent = 'Solarstrahlung pro Stunde';
+            selectors.tableSubtitle.textContent = 'Strahlungswerte zur Planung von Photovoltaik und Energie-Management.';
+            selectors.chartNote.textContent = datasetConfig.solar.chart.note;
+            selectors.dataSource.textContent = `Quelle: ${payload.meta?.source ?? 'Open‑Meteo'}`;
+        },
+    },
 };
 
 const ctx = document.getElementById('chartCanvas').getContext('2d');
-const dataChart = new Chart(ctx, {
-    type: chartType,
+const chart = new Chart(ctx, {
+    type: state.chartType,
     data: {
         labels: [],
-        datasets: [{
-            label: 'Views',
-            data: [],
-            backgroundColor: 'blue',
-            borderColor: 'rgba(75, 192, 192, 1)',
-            borderWidth: 1
-        },{
-            label: 'Likes',
-            data: [],
-            backgroundColor: 'green',
-            borderColor: 'rgba(75, 192, 192, 1)',
-            borderWidth: 1
-        },{
-            label: 'Dislikes',
-            data: [],
-            backgroundColor: 'red',
-            borderColor: 'rgba(75, 192, 192, 1)',
-            borderWidth: 1
-        }]
+        datasets: [],
     },
     options: {
         responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
         scales: {
-            y: { beginAtZero: true }
-        }
-    }
+            y: {
+                beginAtZero: false,
+                ticks: {
+                    color: '#4b5563',
+                },
+            },
+            x: {
+                ticks: {
+                    color: '#6b7280',
+                },
+            },
+        },
+        plugins: {
+            legend: {
+                position: 'top',
+                labels: {
+                    usePointStyle: true,
+                    padding: 20,
+                },
+            },
+        },
+    },
 });
 
-const loadData = (page) => {
-    currentPage = 1;
-    currentDataSet = [];
-
-    fetch(`/api/${page}`)
-        .then((response) => response.json())
-        .then((data) => {
-            // TODO: remove in prod | maybe handle different response.data i.e. here posts and so on
-            if (data.posts) data = data.posts;
-            currentDataSet = data;
-            updateTable(currentDataSet);
-            updateChart(currentDataSet);
-        })
-        .catch((error) => {
-            tableBody.innerHTML = `
-                <tr>
-                    <td colspan="5" class="text-danger text-center">Error loading data!</td>
-                </tr>`;
-            console.error('Error loading data:', error);
-        });
+const showLoader = () => {
+    selectors.tableHead.innerHTML = '';
+    selectors.tableBody.innerHTML = `
+        <tr>
+            <td colspan="6" class="py-5">
+                <div class="d-flex flex-column align-items-center gap-2 text-muted">
+                    <div class="spinner-border text-primary" role="status"></div>
+                    <small>Live-Daten werden geladen …</small>
+                </div>
+            </td>
+        </tr>`;
+    selectors.tableMeta.textContent = 'Daten werden geladen …';
 };
 
-const updateTable = (currentDataSet) => {
-    tableBody.innerHTML = '';
-    const start = (currentPage - 1) * entriesPerPage;
-    const end = start + entriesPerPage;
-    const pageData = currentDataSet.slice(start, end);
+const loadDataset = async (type) => {
+    const config = datasetConfig[type];
+    if (!config) {
+        return;
+    }
 
-    pageData.forEach((item, index) => {
-        const row = `
+    if (!state.data[type]) {
+        showLoader();
+    }
+
+    try {
+        const response = await fetch(config.endpoint, { headers: { Accept: 'application/json' } });
+        if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        state.data[type] = payload;
+        state.currentDataset = type;
+        state.currentPage = 1;
+
+        applyDataset(type, payload);
+        highlightActiveButton(type);
+        window.showSnackbar?.('Daten erfolgreich aktualisiert.');
+    } catch (error) {
+        console.error('Error fetching dataset', error);
+        selectors.tableBody.innerHTML = `
             <tr>
-                <th scope="row">${start + index + 1}</th>
-                <td>${item.title}</td>
-                <td>${item.views}</td>
-                <td>${item.reactions.likes}</td>
-                <td>${item.reactions.dislikes}</td>
-            </tr>
-        `;
-        tableBody.insertAdjacentHTML('beforeend', row);
+                <td colspan="6" class="text-center text-danger py-5">
+                    Fehler beim Laden der Daten. Bitte später erneut versuchen.
+                </td>
+            </tr>`;
+        selectors.tableMeta.textContent = 'Keine Daten verfügbar.';
+        window.showSnackbar?.('Die Daten konnten nicht geladen werden.', 'danger');
+    }
+};
+
+const applyDataset = (type, payload) => {
+    const config = datasetConfig[type];
+    if (!config) {
+        return;
+    }
+
+    config.apply?.(payload);
+    renderTable(type, payload.hourly ?? []);
+    updateChart(type, payload.hourly ?? []);
+};
+
+const renderTable = (type, rows) => {
+    const config = datasetConfig[type];
+    const columns = config.table.columns;
+
+    selectors.tableHead.innerHTML = columns
+        .map((column) => `<th scope="col">${column.label}</th>`)
+        .join('');
+
+    if (!rows.length) {
+        selectors.tableBody.innerHTML = `
+            <tr>
+                <td colspan="${columns.length}" class="text-center text-muted py-5">Keine Datensätze verfügbar</td>
+            </tr>`;
+        selectors.tableMeta.textContent = 'Keine Daten vorhanden.';
+        selectors.currentPage.textContent = '1';
+        return;
+    }
+
+    const start = (state.currentPage - 1) * state.entriesPerPage;
+    const end = start + state.entriesPerPage;
+    const pageRows = rows.slice(start, end);
+
+    selectors.tableBody.innerHTML = pageRows
+        .map((row) => `
+            <tr>
+                ${columns
+                    .map((column) => `<td>${column.formatter?.(row[column.key], row, column) ?? sanitize(row[column.key])}</td>`)
+                    .join('')}
+            </tr>`)
+        .join('');
+
+    selectors.currentPage.textContent = String(state.currentPage);
+    selectors.tableMeta.textContent = `Zeigt ${pageRows.length ? start + 1 : 0} – ${start + pageRows.length} von ${rows.length} Datensätzen`;
+};
+
+const updateChart = (type, rows) => {
+    const config = datasetConfig[type];
+    const datasets = config.chart.datasets;
+    const labels = rows.map((row) => formatHour(row.time));
+
+    chart.config.type = state.chartType;
+    chart.data.labels = labels;
+    chart.data.datasets = datasets.map((dataset) => ({
+        label: dataset.label,
+        data: rows.map((row) => row[dataset.key] ?? null),
+        backgroundColor: dataset.backgroundColor,
+        borderColor: dataset.borderColor,
+        fill: state.chartType === 'line',
+        tension: 0.35,
+        pointRadius: 3,
+    }));
+
+    chart.update();
+};
+
+const highlightActiveButton = (type) => {
+    document.querySelectorAll('.dataset-switch').forEach((button) => {
+        if (button.dataset.dataset === type) {
+            button.classList.add('active');
+        } else {
+            button.classList.remove('active');
+        }
     });
-
-    if (pageData.length === 0) {
-        tableBody.innerHTML = '<tr><td colspan="5" class="text-center">No data available</td></tr>';
-    }
-
-    document.getElementById('currentPage').textContent = currentPage;
-}
-
-const updateChart = (currentDataSet) => {
-    dataChart.data.labels = currentDataSet.map(item => item.title);
-    dataChart.data.datasets[0].data = currentDataSet.map(item => item.views);
-    dataChart.data.datasets[1].data = currentDataSet.map(item => item.reactions.likes);
-    dataChart.data.datasets[2].data = currentDataSet.map(item => item.reactions.dislikes);
-    dataChart.update();
-}
-
-const previousPage = () => {
-    if (currentPage > 1) {
-        currentPage--;
-        updateTable(currentDataSet);
-    }
-}
-
-const nextPage =() => {
-    if (currentPage * entriesPerPage < currentDataSet.length) {
-        currentPage++;
-        updateTable(currentDataSet);
-    }
-}
+};
 
 const setChartType = (type) => {
-    chartType = type;
-    dataChart.config.type = chartType;
-    dataChart.update();
-}
+    state.chartType = type;
+    const payload = state.data[state.currentDataset];
+    if (payload) {
+        updateChart(state.currentDataset, payload.hourly ?? []);
+    }
+};
 
-const buttons = document.querySelectorAll('button[data-page]');
+const previousPage = () => {
+    if (state.currentPage <= 1) {
+        return;
+    }
+    state.currentPage -= 1;
+    const payload = state.data[state.currentDataset];
+    if (payload) {
+        renderTable(state.currentDataset, payload.hourly ?? []);
+    }
+};
 
-buttons.forEach((button) => {
+const nextPage = () => {
+    const payload = state.data[state.currentDataset];
+    if (!payload) {
+        return;
+    }
+
+    const rows = payload.hourly ?? [];
+    if (state.currentPage * state.entriesPerPage >= rows.length) {
+        return;
+    }
+
+    state.currentPage += 1;
+    renderTable(state.currentDataset, rows);
+};
+
+const formatNumber = (value, suffix = '', fallback = '--') => {
+    if (value === null || value === undefined || Number.isNaN(Number(value))) {
+        return fallback;
+    }
+    const number = Number(value);
+    const options = { minimumFractionDigits: 0, maximumFractionDigits: 1 };
+    return `${number.toLocaleString('de-DE', options)}${suffix}`;
+};
+
+const sanitize = (value) => {
+    if (value === null || value === undefined) {
+        return '--';
+    }
+    return String(value);
+};
+
+const formatHour = (isoString) => {
+    if (!isoString) {
+        return '--';
+    }
+    const [datePart, timePart = ''] = isoString.split('T');
+    const time = timePart.slice(0, 5);
+    if (!datePart) {
+        return `${time} Uhr`;
+    }
+    const [year, month, day] = datePart.split('-');
+    return `${time} Uhr (${day}.${month})`;
+};
+
+const formatDateTime = (isoString) => {
+    if (!isoString) {
+        return '--';
+    }
+    const [datePart, timePart = ''] = isoString.split('T');
+    if (!datePart) {
+        return isoString;
+    }
+    const [year, month, day] = datePart.split('-');
+    const time = timePart.slice(0, 5);
+    return `${day}.${month}.${year} · ${time} Uhr`;
+};
+
+const averageFromSeries = (rows, key) => {
+    if (!rows.length) {
+        return null;
+    }
+    const filtered = rows
+        .map((row) => (typeof row[key] === 'number' ? row[key] : Number(row[key])))
+        .filter((value) => !Number.isNaN(value));
+    if (!filtered.length) {
+        return null;
+    }
+    const sum = filtered.reduce((acc, value) => acc + value, 0);
+    return sum / filtered.length;
+};
+
+const datasetButtons = document.querySelectorAll('.dataset-switch');
+
+datasetButtons.forEach((button) => {
     button.addEventListener('click', () => {
-        buttons.forEach((btn) => btn.classList.remove('btn-success'));
-        button.classList.add('btn-success');
-
-        showLoader();
-        loadData(button.getAttribute('data-page'));
+        const dataset = button.dataset.dataset;
+        if (!dataset || dataset === state.currentDataset) {
+            return;
+        }
+        loadDataset(dataset);
     });
 });
 
 showLoader();
-buttons[0].classList.add('btn-success');
-loadData('page1');
+loadDataset(state.currentDataset);
+
+window.setChartType = setChartType;
+window.previousPage = previousPage;
+window.nextPage = nextPage;

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Exception\ExternalApiException;
+use App\Service\WeatherService;
+use JsonException;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class ApiController
+{
+    public function __construct(private readonly WeatherService $weatherService)
+    {
+    }
+
+    public function overview(Request $request, Response $response): Response
+    {
+        return $this->respond(fn () => $this->weatherService->fetchOverview(), $response);
+    }
+
+    public function airQuality(Request $request, Response $response): Response
+    {
+        return $this->respond(fn () => $this->weatherService->fetchAirQuality(), $response);
+    }
+
+    public function solar(Request $request, Response $response): Response
+    {
+        return $this->respond(fn () => $this->weatherService->fetchSolar(), $response);
+    }
+
+    private function respond(callable $callback, Response $response): Response
+    {
+        try {
+            $payload = $callback();
+            $body = json_encode($payload, JSON_THROW_ON_ERROR);
+        } catch (ExternalApiException $exception) {
+            return $this->errorResponse($response, 502, $exception->getMessage());
+        } catch (JsonException) {
+            return $this->errorResponse($response, 500, 'Die Antwort konnte nicht verarbeitet werden.');
+        }
+
+        $response->getBody()->write($body);
+
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+
+    private function errorResponse(Response $response, int $status, string $message): Response
+    {
+        $payload = json_encode([
+            'error' => true,
+            'message' => $message,
+        ], JSON_THROW_ON_ERROR);
+
+        $response->getBody()->write($payload);
+
+        return $response
+            ->withStatus($status)
+            ->withHeader('Content-Type', 'application/json');
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -4,13 +4,17 @@ declare(strict_types = 1);
 
 namespace App\Controller;
 
+use App\Service\WeatherService;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Slim\Views\Twig;
 
 class DashboardController
 {
-    public function __construct(private readonly Twig $twig)
+    public function __construct(
+        private readonly Twig $twig,
+        private readonly WeatherService $weatherService
+    )
     {
     }
 
@@ -19,7 +23,8 @@ class DashboardController
         $user = $request->getAttribute('user');
 
         return $this->twig->render($response, 'dashboard/index.twig', [
-            'username' => $user->sub
+            'username' => $user->sub,
+            'defaultLocation' => $this->weatherService->getLocationLabel(),
         ]);
     }
 }

--- a/src/Exception/ExternalApiException.php
+++ b/src/Exception/ExternalApiException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use RuntimeException;
+
+class ExternalApiException extends RuntimeException
+{
+}

--- a/src/Service/WeatherService.php
+++ b/src/Service/WeatherService.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Exception\ExternalApiException;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use JsonException;
+
+class WeatherService
+{
+    private const FORECAST_ENDPOINT = 'https://api.open-meteo.com/v1/forecast';
+    private const AIR_QUALITY_ENDPOINT = 'https://air-quality-api.open-meteo.com/v1/air-quality';
+
+    public function __construct(
+        private readonly float $latitude = 52.52,
+        private readonly float $longitude = 13.41,
+        private readonly string $locationLabel = 'Berlin, Deutschland',
+        private readonly string $timezone = 'Europe/Berlin'
+    ) {
+    }
+
+    public function fetchOverview(): array
+    {
+        $params = [
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'hourly' => 'temperature_2m,apparent_temperature,relativehumidity_2m,precipitation_probability,precipitation,wind_speed_10m',
+            'current' => 'temperature_2m,apparent_temperature,relativehumidity_2m,wind_speed_10m,weather_code',
+            'daily' => 'sunrise,sunset',
+            'forecast_days' => 1,
+            'timezone' => $this->timezone,
+        ];
+
+        $payload = $this->request(self::FORECAST_ENDPOINT, $params);
+
+        $hourly = $this->buildHourlySeries(
+            $payload['hourly']['time'] ?? [],
+            $payload['hourly'] ?? [],
+            [
+                'temperature' => 'temperature_2m',
+                'apparentTemperature' => 'apparent_temperature',
+                'humidity' => 'relativehumidity_2m',
+                'precipitationProbability' => 'precipitation_probability',
+                'precipitation' => 'precipitation',
+                'windSpeed' => 'wind_speed_10m',
+            ]
+        );
+
+        $temperatures = array_column($hourly, 'temperature');
+        $windSpeeds = array_column($hourly, 'windSpeed');
+        $precipitationProbabilities = array_column($hourly, 'precipitationProbability');
+
+        $current = $payload['current'] ?? [];
+
+        return [
+            'meta' => [
+                'location' => $this->locationLabel,
+                'coordinates' => [
+                    'latitude' => $this->latitude,
+                    'longitude' => $this->longitude,
+                ],
+                'timezone' => $payload['timezone'] ?? $this->timezone,
+                'source' => 'Open-Meteo Forecast API',
+                'updatedAt' => $current['time'] ?? null,
+            ],
+            'current' => [
+                'temperature' => $this->roundValue($current['temperature_2m'] ?? null),
+                'apparentTemperature' => $this->roundValue($current['apparent_temperature'] ?? null),
+                'humidity' => $this->roundValue($current['relativehumidity_2m'] ?? null),
+                'windSpeed' => $this->roundValue($current['wind_speed_10m'] ?? null),
+                'weatherCode' => $current['weather_code'] ?? null,
+                'description' => $this->describeWeather($current['weather_code'] ?? null),
+                'time' => $current['time'] ?? null,
+            ],
+            'hourly' => $hourly,
+            'highlights' => [
+                'maxTemperature' => $this->roundValue($temperatures ? max($temperatures) : null),
+                'minTemperature' => $this->roundValue($temperatures ? min($temperatures) : null),
+                'averageWindSpeed' => $this->roundValue($windSpeeds ? $this->average($windSpeeds) : null),
+                'rainChance' => $this->roundValue($precipitationProbabilities ? max($precipitationProbabilities) : null),
+                'sunrise' => $payload['daily']['sunrise'][0] ?? null,
+                'sunset' => $payload['daily']['sunset'][0] ?? null,
+            ],
+        ];
+    }
+
+    public function getLocationLabel(): string
+    {
+        return $this->locationLabel;
+    }
+
+    public function fetchAirQuality(): array
+    {
+        $params = [
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'hourly' => 'pm10,pm2_5,ozone,carbon_monoxide',
+            'forecast_days' => 1,
+            'timezone' => $this->timezone,
+        ];
+
+        $payload = $this->request(self::AIR_QUALITY_ENDPOINT, $params);
+
+        $hourly = $this->buildHourlySeries(
+            $payload['hourly']['time'] ?? [],
+            $payload['hourly'] ?? [],
+            [
+                'pm10' => 'pm10',
+                'pm25' => 'pm2_5',
+                'ozone' => 'ozone',
+                'carbonMonoxide' => 'carbon_monoxide',
+            ]
+        );
+
+        $pm25Values = array_column($hourly, 'pm25');
+        $pm10Values = array_column($hourly, 'pm10');
+        $ozoneValues = array_column($hourly, 'ozone');
+
+        $aqi = $this->calculateAirQualityIndex($pm25Values);
+
+        return [
+            'meta' => [
+                'location' => $this->locationLabel,
+                'coordinates' => [
+                    'latitude' => $this->latitude,
+                    'longitude' => $this->longitude,
+                ],
+                'timezone' => $payload['timezone'] ?? $this->timezone,
+                'source' => 'Open-Meteo Air Quality API',
+                'updatedAt' => $hourly[0]['time'] ?? null,
+            ],
+            'hourly' => $hourly,
+            'highlights' => [
+                'averagePm25' => $this->roundValue($pm25Values ? $this->average($pm25Values) : null),
+                'maxPm10' => $this->roundValue($pm10Values ? max($pm10Values) : null),
+                'maxOzone' => $this->roundValue($ozoneValues ? max($ozoneValues) : null),
+            ],
+            'airQualityIndex' => $aqi,
+        ];
+    }
+
+    public function fetchSolar(): array
+    {
+        $params = [
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+            'hourly' => 'shortwave_radiation,diffuse_radiation,direct_radiation,direct_normal_irradiance',
+            'daily' => 'sunrise,sunset',
+            'forecast_days' => 1,
+            'timezone' => $this->timezone,
+        ];
+
+        $payload = $this->request(self::FORECAST_ENDPOINT, $params);
+
+        $hourly = $this->buildHourlySeries(
+            $payload['hourly']['time'] ?? [],
+            $payload['hourly'] ?? [],
+            [
+                'shortwaveRadiation' => 'shortwave_radiation',
+                'diffuseRadiation' => 'diffuse_radiation',
+                'directRadiation' => 'direct_radiation',
+                'directNormalIrradiance' => 'direct_normal_irradiance',
+            ]
+        );
+
+        $directRadiation = array_column($hourly, 'directRadiation');
+
+        $sunrise = $payload['daily']['sunrise'][0] ?? null;
+        $sunset = $payload['daily']['sunset'][0] ?? null;
+        $daylightHours = $sunrise && $sunset ? $this->calculateDaylightHours($sunrise, $sunset) : null;
+
+        return [
+            'meta' => [
+                'location' => $this->locationLabel,
+                'coordinates' => [
+                    'latitude' => $this->latitude,
+                    'longitude' => $this->longitude,
+                ],
+                'timezone' => $payload['timezone'] ?? $this->timezone,
+                'source' => 'Open-Meteo Solar Radiation Model',
+                'updatedAt' => $hourly[0]['time'] ?? null,
+            ],
+            'hourly' => $hourly,
+            'highlights' => [
+                'peakRadiation' => $this->roundValue($directRadiation ? max($directRadiation) : null),
+                'sunrise' => $sunrise,
+                'sunset' => $sunset,
+                'daylightHours' => $daylightHours,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $series
+     * @return array<int, array<string, float|string|null>>
+     */
+    private function buildHourlySeries(array $time, array $series, array $mapping, int $limit = 12): array
+    {
+        $result = [];
+
+        foreach ($time as $index => $timestamp) {
+            if ($index >= $limit) {
+                break;
+            }
+
+            $entry = ['time' => $timestamp];
+
+            foreach ($mapping as $alias => $sourceKey) {
+                $values = $series[$sourceKey] ?? [];
+                $entry[$alias] = isset($values[$index]) ? $this->roundValue($values[$index]) : null;
+            }
+
+            $result[] = $entry;
+        }
+
+        return $result;
+    }
+
+    private function request(string $endpoint, array $params): array
+    {
+        $queryString = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+        $url = sprintf('%s?%s', $endpoint, $queryString);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'header' => [
+                    'Accept: application/json',
+                    'User-Agent: SlimDashboard/1.0',
+                ],
+                'timeout' => 8,
+            ],
+        ]);
+
+        $response = @file_get_contents($url, false, $context);
+
+        if ($response === false) {
+            throw new ExternalApiException('Die externen Wetterdaten konnten nicht geladen werden.');
+        }
+
+        try {
+            return json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new ExternalApiException('Die Antwort des Wetterdienstes ist ungültig.', 0, $exception);
+        }
+    }
+
+    /**
+     * @param array<int, float|int|null> $values
+     */
+    private function average(array $values): float
+    {
+        $filtered = array_values(array_filter($values, static fn ($value) => $value !== null));
+
+        if ($filtered === []) {
+            return 0.0;
+        }
+
+        return array_sum($filtered) / count($filtered);
+    }
+
+    private function roundValue(float|int|null $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return round((float) $value, 1);
+    }
+
+    /**
+     * @param array<int, float|int|null> $pm25Values
+     */
+    private function calculateAirQualityIndex(array $pm25Values): array
+    {
+        $average = $pm25Values ? $this->average($pm25Values) : 0.0;
+
+        if ($average <= 12) {
+            $category = 'Ausgezeichnet';
+            $color = 'success';
+            $message = 'Die Luftqualität ist hervorragend.';
+        } elseif ($average <= 35.4) {
+            $category = 'Gut';
+            $color = 'primary';
+            $message = 'Leichte Belastung, bestens geeignet für Outdoor-Aktivitäten.';
+        } elseif ($average <= 55.4) {
+            $category = 'Mittel';
+            $color = 'warning';
+            $message = 'Empfindliche Personen sollten Aktivitäten im Freien reduzieren.';
+        } else {
+            $category = 'Belastet';
+            $color = 'danger';
+            $message = 'Hohe Belastung – Aufenthalt im Freien möglichst meiden.';
+        }
+
+        return [
+            'score' => $this->roundValue($average),
+            'category' => $category,
+            'color' => $color,
+            'message' => $message,
+        ];
+    }
+
+    private function describeWeather(?int $code): string
+    {
+        return match ($code) {
+            0 => 'Klarer Himmel',
+            1, 2 => 'Leicht bewölkt',
+            3 => 'Bedeckt',
+            45, 48 => 'Nebel',
+            51, 53, 55 => 'Leichter Nieselregen',
+            56, 57 => 'Gefrierender Nieselregen',
+            61 => 'Leichter Regen',
+            63 => 'Mäßiger Regen',
+            65 => 'Starker Regen',
+            66, 67 => 'Gefrierender Regen',
+            71, 73, 75 => 'Schneefall',
+            77 => 'Schneekörner',
+            80 => 'Leichte Schauer',
+            81 => 'Mäßige Schauer',
+            82 => 'Heftige Schauer',
+            85, 86 => 'Schneeschauer',
+            95 => 'Gewitter',
+            96, 99 => 'Gewitter mit Hagel',
+            default => 'Wird aktualisiert…',
+        };
+    }
+
+    private function calculateDaylightHours(string $sunrise, string $sunset): ?float
+    {
+        try {
+            $start = new DateTimeImmutable($sunrise, new DateTimeZone($this->timezone));
+            $end = new DateTimeImmutable($sunset, new DateTimeZone($this->timezone));
+        } catch (\Exception) {
+            return null;
+        }
+
+        $interval = $start->diff($end);
+
+        if (!$interval instanceof DateInterval) {
+            return null;
+        }
+
+        $hours = ($interval->days * 24) + $interval->h + ($interval->i / 60);
+
+        return round($hours, 1);
+    }
+}

--- a/templates/dashboard/index.twig
+++ b/templates/dashboard/index.twig
@@ -10,66 +10,148 @@
 {% endblock %}
 
 {% block content %}
-
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm mb-4">
-        <div class="container">
-            <a class="navbar-brand fw-bold" href="#">Dashboard</a>
-        </div>
-    </nav>
-
-    <div class="container py-5">
-        <h2 class="text-center mb-4 fw-bold">Hallo {{ username }}</h1>
-
-        <!-- Buttons for Data Selection -->
-        <div class="d-flex justify-content-center mb-4">
-            <button class="btn btn-primary mx-2"  data-page="page1">Load Data 1</button>
-            <button class="btn btn-primary mx-2" data-page="page2">Load Data 2</button>
-            <button class="btn btn-primary mx-2" data-page="page3">Load Data 3</button>
-        </div>
-
-        <!-- Data Table -->
-        <div class="card mb-4" id="dataTable">
-            <div class="card-body">
-                <h5 class="card-title">Data Table</h5>
-                <table class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th scope="col">#</th>
-                            <th scope="col">Title</th>
-                            <th scope="col">Views</th>
-                            <th scope="col">Likes</th>
-                            <th scope="col">Dislikes</th>
-                        </tr>
-                    </thead>
-                    <tbody id="dataTableBody">
-                        <tr>
-                            <td colspan="5" class="text-center">No data loaded</td>
-                        </tr>
-                    </tbody>
-                </table>
-                <nav class="d-flex justify-content-center">
-                    <ul class="pagination">
-                        <li class="page-item"><button class="page-link" onclick="previousPage()">«</button></li>
-                        <li class="page-item active"><span class="page-link" id="currentPage">1</span></li>
-                        <li class="page-item"><button class="page-link" onclick="nextPage()">»</button></li>
-                    </ul>
-                </nav>
-            </div>
-        </div>
-
-        <!-- Chart -->
-        <div class="card" id="dataChart">
-            <div class="card-body">
-                <h5 class="card-title">Chart</h5>
-                <div class="chart-controls">
-                    <button class="btn btn-outline-primary btn-sm" onclick="setChartType('bar')">Bar</button>
-                    <button class="btn btn-outline-primary btn-sm" onclick="setChartType('line')">Line</button>
-                    {# <button class="btn btn-outline-primary btn-sm" onclick="setChartType('pie')">Pie</button> #}
+    <header class="dashboard-hero gradient-bg text-white py-5">
+        <div class="container d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-4">
+            <div>
+                <span class="badge rounded-pill bg-white text-dark mb-3 px-3 py-2 shadow-sm">Live Climate Intelligence</span>
+                <h1 class="display-5 fw-semibold mb-3">Hallo {{ username }}, willkommen im Smart Climate Cockpit</h1>
+                <p class="lead text-white-50 mb-4">
+                    Bleibe jederzeit über Wetter, Luftqualität und Sonnenaktivität in deiner Stadt informiert –
+                    mit Daten direkt von Open‑Meteo.
+                </p>
+                <div class="d-flex flex-wrap align-items-center gap-3 hero-meta">
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="hero-icon">📍</span>
+                        <span id="locationLabel" class="fw-medium">{{ defaultLocation }}</span>
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="hero-icon">🌡️</span>
+                        <span class="fs-4" id="heroTemperature">--°C</span>
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                        <span class="hero-icon">☁️</span>
+                        <span id="heroCondition">Wird geladen…</span>
+                    </div>
                 </div>
-                <canvas id="chartCanvas" height="100"></canvas>
+            </div>
+            <div class="glass-card text-dark p-4 shadow-lg">
+                <p class="text-uppercase small fw-semibold text-muted mb-1">Aktuelles Wetter</p>
+                <div class="d-flex align-items-baseline gap-3 mb-2">
+                    <span class="display-4 fw-bold text-primary" id="currentTemperature">--°C</span>
+                    <div>
+                        <p class="mb-0 text-muted">Feels like <span id="currentFeelsLike">--°C</span></p>
+                        <p class="mb-0 text-muted">Letztes Update <span id="currentUpdatedAt">--</span></p>
+                    </div>
+                </div>
+                <div class="row g-3">
+                    <div class="col">
+                        <div class="metric-pill" data-metric="primary">
+                            <span class="label">Luftfeuchtigkeit</span>
+                            <span class="value" id="currentHumidity">--%</span>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="metric-pill" data-metric="secondary">
+                            <span class="label">Wind</span>
+                            <span class="value" id="currentWind">-- km/h</span>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="metric-pill" data-metric="tertiary">
+                            <span class="label">Regenrisiko</span>
+                            <span class="value" id="currentRainChance">--%</span>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
+    </header>
 
+    <main class="container py-5">
+        <div class="row align-items-center mb-4">
+            <div class="col-lg-6">
+                <h2 class="fw-semibold mb-2">Daten-Explorer</h2>
+                <p class="text-muted mb-0">Wechsle zwischen den Perspektiven, um detaillierte Einblicke in Temperaturverläufe,
+                    Luftqualität und Solarleistung zu erhalten.</p>
+            </div>
+            <div class="col-lg-6 d-flex justify-content-lg-end mt-3 mt-lg-0">
+                <div class="btn-group" role="group" aria-label="Dataset selector">
+                    <button class="btn btn-outline-primary dataset-switch active" data-dataset="weather">Wetter</button>
+                    <button class="btn btn-outline-primary dataset-switch" data-dataset="air-quality">Luftqualität</button>
+                    <button class="btn btn-outline-primary dataset-switch" data-dataset="solar">Solarenergie</button>
+                </div>
+            </div>
+        </div>
+
+        <section class="row g-4 mb-4" id="insightTiles">
+            <div class="col-md-4">
+                <div class="glass-card h-100" data-highlight="primary">
+                    <span class="badge rounded-pill bg-primary-subtle text-primary mb-2">Temperatur</span>
+                    <h5 class="fw-semibold" id="highlightPrimaryTitle">Tagesverlauf</h5>
+                    <p class="text-muted mb-0" id="highlightPrimaryText">Max --°C · Min --°C</p>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="glass-card h-100" data-highlight="secondary">
+                    <span class="badge rounded-pill bg-success-subtle text-success mb-2">Wind</span>
+                    <h5 class="fw-semibold" id="highlightSecondaryTitle">Durchschnittliche Geschwindigkeit</h5>
+                    <p class="text-muted mb-0" id="highlightSecondaryText">-- km/h</p>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="glass-card h-100" data-highlight="tertiary">
+                    <span class="badge rounded-pill bg-warning-subtle text-warning mb-2">Sonne</span>
+                    <h5 class="fw-semibold" id="highlightTertiaryTitle">Tageslicht</h5>
+                    <p class="text-muted mb-0" id="highlightTertiaryText">Aufgang -- · Untergang --</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="row g-4">
+            <div class="col-lg-7">
+                <div class="glass-card h-100">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <div>
+                            <h5 class="fw-semibold mb-1" id="tableTitle">Stündliche Wetterdaten</h5>
+                            <span class="text-muted small" id="tableSubtitle">Vergleich von Temperatur, gefühlter Temperatur und Luftfeuchte.</span>
+                        </div>
+                        <div>
+                            <button class="btn btn-sm btn-outline-secondary" onclick="setChartType('line')">Line</button>
+                            <button class="btn btn-sm btn-outline-secondary" onclick="setChartType('bar')">Bar</button>
+                        </div>
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table align-middle" id="dataTable">
+                            <thead>
+                                <tr id="tableHeadRow"></tr>
+                            </thead>
+                            <tbody id="dataTableBody">
+                                <tr>
+                                    <td colspan="6" class="text-center text-muted py-5">Noch keine Daten geladen</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mt-3 flex-wrap gap-2">
+                        <nav aria-label="Pagination" class="mb-0">
+                            <ul class="pagination pagination-rounded mb-0">
+                                <li class="page-item"><button class="page-link" onclick="previousPage()">«</button></li>
+                                <li class="page-item active"><span class="page-link" id="currentPage">1</span></li>
+                                <li class="page-item"><button class="page-link" onclick="nextPage()">»</button></li>
+                            </ul>
+                        </nav>
+                        <span class="text-muted small" id="tableMeta">Zeigt 0 von 0 Datensätzen</span>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-5">
+                <div class="glass-card h-100">
+                    <h5 class="fw-semibold mb-3">Visual Analytics</h5>
+                    <canvas id="chartCanvas" height="240"></canvas>
+                    <p class="text-muted small mt-3" id="chartNote">Visualisierung basierend auf stündlichen Wetterdaten.</p>
+                    <div class="text-muted small mt-2" id="dataSource">Quelle: Open‑Meteo</div>
+                </div>
+            </div>
+        </section>
+    </main>
 {% endblock %}

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -7,9 +7,11 @@
         <title>{% block title %}{% endblock %}</title>
         
         {% block stylesheets %}
-            <!-- Bootstrap CSS -->
+            <link rel="preconnect" href="https://fonts.googleapis.com">
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+            <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
             <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-            <!-- MDB -->
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.20.0/css/mdb.min.css">
             <link rel="stylesheet" href="../assets/css/style.css">
         {% endblock %}


### PR DESCRIPTION
## Summary
- introduce a WeatherService and ApiController that call Open-Meteo forecast, air-quality and solar endpoints to replace the dummy JSON data
- inject the new service into the dashboard, expose richer API routes, and overhaul the dashboard Twig template plus JavaScript to handle dataset switching, charts and highlights
- refresh the layout and CSS with a modern gradient/glass design and typography to deliver a contemporary UX

## Testing
- not run (vendor tree missing in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7e0a0aa28832fa1aa756eb6741be2