### PR TITLE
Remove unsupported `depends_on` health condition in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
   nginx:
     image: nginx:1.25-alpine
     depends_on:
-      php:
-        condition: service_healthy
+      - php
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
### Motivation
- Fix a startup error by removing the unsupported `depends_on` `condition: service_healthy` usage in `docker-compose.yml` which uses Compose file version `3.9` where conditional dependencies are not supported.

### Description
- Replace the conditional `depends_on` mapping with a simple list entry so `nginx` depends on `php` (`depends_on: - php`) in `docker-compose.yml`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970e843ec48832fb2936e530ce597ea)